### PR TITLE
Update sps-rs3.simba

### DIFF
--- a/lib/sps-rs3.simba
+++ b/lib/sps-rs3.simba
@@ -245,7 +245,7 @@ end;
 
 function TSPSArea.walkToPos(pos: TPoint): boolean; overload;
 begin
-  self.walkToPos(pos, self.getPlayerPos());
+  result := self.walkToPos(pos, self.getPlayerPos());
 end;
 
 function TSPSArea.walkPath(path: TPointArray): boolean;


### PR DESCRIPTION
changed the overloaded walkToPos function to return a result:
function TSPSArea.walkToPos(pos: TPoint): boolean; overload;
begin
  result := self.walkToPos(pos, self.getPlayerPos());
end;
