### PR TITLE
Fix SPS_MakeColorBox using garbage value

### DIFF
--- a/plugin/source/sps.lpr
+++ b/plugin/source/sps.lpr
@@ -51,6 +51,7 @@ procedure SPS_MakeColorBox(bmp: TMufasaBitmap; x1, y1, SideLength: integer; var 
 var
   x, y, C, R, G, B: integer;
 begin
+  SetLength(Res, 0);
   SetLength(Res, 3);
 
   for x := (x1 + SideLength - 1) downto x1 do


### PR DESCRIPTION
If res is not empty it will be added to the rgb values (line 63-65), so it should be cleared at the start.
